### PR TITLE
added option to delete children of page along with page

### DIFF
--- a/ProcessBatcher.module
+++ b/ProcessBatcher.module
@@ -666,7 +666,7 @@ class ProcessBatcher extends Process implements Module
             case 'deleteWithChildren' :
                 foreach ($pages as $p) { 
                     // add the number of child pages to the count                   
-                    $count = $p->numChildren();
+                    $count += $p->numChildren();
                     $p->of(false);
                     wire('pages')->delete($p, true); 
                     // add the page itself to the count

--- a/ProcessBatcher.module
+++ b/ProcessBatcher.module
@@ -37,6 +37,7 @@ class ProcessBatcher extends Process implements Module
             'unlock' => $this->_('Unlock'),
             'trash' => $this->_('Trash'),
             'delete' => $this->_('Delete'),
+            'delete_with_children' => $this->_('Delete (include child pages)'),
             'changeTemplate' => $this->_('Change Template'),
             'changeParent' => $this->_('Change Parent'),
         );
@@ -234,6 +235,7 @@ class ProcessBatcher extends Process implements Module
     {
         $actions = $this->actions;
         if (!$this->user->hasPermission('page-delete')) unset($actions['delete']);
+        if (!$this->user->hasPermission('page-delete')) unset($actions['delete_with_children']);
         if (!$this->user->hasPermission('page-move')) unset($actions['changeParent']);
         if (!$this->user->hasPermission('page-template')) unset($actions['changeTemplate']);
         if (!$this->user->hasPermission('page-lock')) {
@@ -658,6 +660,16 @@ class ProcessBatcher extends Process implements Module
                     $p->of(false);
                     $p->delete();
                     $count++;
+                }
+                $message = $this->_(sprintf("Deleted %d pages", $count));
+                break;
+            case 'delete_with_children' :
+                foreach ($pages as $p) {
+                    $children = wire('pages')->find('has_parent=' . $pages->get($p));
+                    $count = $count + $children->count();
+                    $p->of(false);
+                    wire('pages')->delete($pages->get($p), true); 
+                    $count++;                              
                 }
                 $message = $this->_(sprintf("Deleted %d pages", $count));
                 break;

--- a/ProcessBatcher.module
+++ b/ProcessBatcher.module
@@ -37,7 +37,7 @@ class ProcessBatcher extends Process implements Module
             'unlock' => $this->_('Unlock'),
             'trash' => $this->_('Trash'),
             'delete' => $this->_('Delete'),
-            'delete_with_children' => $this->_('Delete (include child pages)'),
+            'deleteWithChildren' => $this->_('Delete (include child pages)'),
             'changeTemplate' => $this->_('Change Template'),
             'changeParent' => $this->_('Change Parent'),
         );
@@ -235,7 +235,7 @@ class ProcessBatcher extends Process implements Module
     {
         $actions = $this->actions;
         if (!$this->user->hasPermission('page-delete')) unset($actions['delete']);
-        if (!$this->user->hasPermission('page-delete')) unset($actions['delete_with_children']);
+        if (!$this->user->hasPermission('page-delete')) unset($actions['deleteWithChildren']);
         if (!$this->user->hasPermission('page-move')) unset($actions['changeParent']);
         if (!$this->user->hasPermission('page-template')) unset($actions['changeTemplate']);
         if (!$this->user->hasPermission('page-lock')) {
@@ -663,13 +663,14 @@ class ProcessBatcher extends Process implements Module
                 }
                 $message = $this->_(sprintf("Deleted %d pages", $count));
                 break;
-            case 'delete_with_children' :
-                foreach ($pages as $p) {
-                    $children = wire('pages')->find('has_parent=' . $pages->get($p));
-                    $count = $count + $children->count();
+            case 'deleteWithChildren' :
+                foreach ($pages as $p) { 
+                    // add the number of child pages to the count                   
+                    $count = $p->numChildren();
                     $p->of(false);
-                    wire('pages')->delete($pages->get($p), true); 
-                    $count++;                              
+                    wire('pages')->delete($p, true); 
+                    // add the page itself to the count
+                    $count++;                        
                 }
                 $message = $this->_(sprintf("Deleted %d pages", $count));
                 break;


### PR DESCRIPTION
Basically just adds an option that runs the $page->delete method with the 'delete children' option set to 'true'. Useful if you have a bunch of different levels in the page hierarchy.